### PR TITLE
Support all non EOL Python versions

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,12 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.12", "3.11", "3.10", "pypy-3.10"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8", "pypy-3.10"]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,12 @@ authors = [
   { name="David C Ellis" },
 ]
 readme="README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = []
 classifiers = [
     "Development Status :: 1 - Planning",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme="README.md"
 requires-python = ">=3.8"
 dependencies = []
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/ducktools/lazyimporter.py
+++ b/src/ducktools/lazyimporter.py
@@ -86,7 +86,7 @@ class _ImportBase(abc.ABC):
 
 class ModuleImport(_ImportBase):
     module_name: str
-    asname: None | str
+    asname: "None | str"
 
     def __init__(self, module_name, asname=None):
         """
@@ -197,7 +197,7 @@ class FromImport(_ImportBase):
 
 class MultiFromImport(_ImportBase):
     module_name: str
-    attrib_names: list[str | tuple[str, str]]
+    attrib_names: "list[str | tuple[str, str]]"
 
     def __init__(self, module_name, attrib_names):
         """
@@ -271,7 +271,7 @@ class MultiFromImport(_ImportBase):
 
 class _SubmoduleImports(_ImportBase):
     module_name: str
-    submodules: set[str]
+    submodules: "set[str]"
 
     def __init__(self, module_name, submodules=None):
         """
@@ -361,7 +361,7 @@ class _ImporterGrouper:
         importers = {}
 
         for imp in inst._imports:  # noqa
-            if imp.import_level > 0 and inst._globals is None:
+            if imp.import_level > 0 and inst._globals is None:  # noqa
                 raise ValueError(
                     "Attempted to setup relative import without providing globals()."
                 )
@@ -409,7 +409,7 @@ class _ImporterGrouper:
 
 
 class LazyImporter:
-    _imports: list[ModuleImport | FromImport | MultiFromImport]
+    _imports: "list[ModuleImport | FromImport | MultiFromImport]"
     _globals: dict
 
     _importers = _ImporterGrouper()

--- a/src/ducktools/lazyimporter.py
+++ b/src/ducktools/lazyimporter.py
@@ -26,7 +26,7 @@ when first accessed.
 import abc
 import sys
 
-__version__ = "v0.1.0"
+__version__ = "v0.1.1"
 __all__ = [
     "LazyImporter",
     "ModuleImport",


### PR DESCRIPTION
Add tests and change classifier to support all non EOL python (>= 3.8 at this time)