### PR TITLE
Add a try/except from importer

### DIFF
--- a/src/ducktools/lazyimporter.pyi
+++ b/src/ducktools/lazyimporter.pyi
@@ -75,6 +75,18 @@ class TryExceptImport(ImportBase):
     def except_module_names(self) -> list[str]: ...
     def do_import(self, globs: dict[str, Any] | None = ...): ...
 
+class TryExceptFromImport(TryExceptImport):
+    def __init__(
+        self,
+        module_name: str,
+        attribute_name: str,
+        except_module: str,
+        except_attribute: str,
+        asname: str,
+    ) -> None: ...
+    def __eq__(self, other): ...
+    def do_import(self, globs: dict[str, Any] | None = ...): ...
+
 class _SubmoduleImports(ImportBase):
     module_name: str
     submodules: set[str]

--- a/tests/test_basic_imports.py
+++ b/tests/test_basic_imports.py
@@ -8,6 +8,7 @@ from ducktools.lazyimporter import (
     FromImport,
     MultiFromImport,
     TryExceptImport,
+    TryExceptFromImport,
 )
 
 
@@ -141,6 +142,18 @@ class TestDirectImports:
 
         assert laz.ex_submod.name == "ex_submod"
 
+    def test_try_except_from_import(self):
+        laz = LazyImporter([
+            TryExceptFromImport("ex_mod", "name", "ex_othermod", "name", "name")
+        ])
+
+        assert laz.name == "ex_mod"
+
+        laz = LazyImporter([
+            TryExceptFromImport("module_does_not_exist", "name", "ex_mod.ex_submod", "name", "name")
+        ])
+
+        assert laz.name == "ex_submod"
 
 class TestRelativeImports:
     def test_relative_import(self):


### PR DESCRIPTION
Add an importer to handle try/except imports with "from x import y" behaviour.

(This is useful in a prefab_classes refactor).