### PR TITLE
Add environment variables/globals/arguments to enable/disable eager process/export

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,24 @@ laz = LazyImporter(
 __getattr__, __dir__ = get_module_funcs(laz, __name__)
 ```
 
+## Environment Variables ##
+
+There are two environment variables that can be used to modify the behaviour for
+debugging purposes.
+
+If `DUCKTOOLS_EAGER_PROCESS` is set to any value other than 'False' (case insensitive)
+the initial processing of imports will be done on instance creation.
+
+Similarly if `DUCKTOOLS_EAGER_IMPORT` is set to any value other than 'False' all imports
+will be performed eagerly on instance creation (this will also force processing on import).
+
+If they are unset this is equivalent to being set to False.
+
+If there is a lazy importer where it is known this will not work 
+(for instance if it is managing a circular dependency issue)
+these can be overridden for an importer by passing values to `eager_process` and/or 
+`eager_import` arguments to the `LazyImporter` constructer as keyword arguments.
+
 ## How does it work ##
 
 The following lazy importer:

--- a/src/ducktools/lazyimporter/__init__.py
+++ b/src/ducktools/lazyimporter/__init__.py
@@ -27,7 +27,7 @@ import abc
 import os
 import sys
 
-__version__ = "v0.5.0"
+__version__ = "v0.5.1"
 __all__ = [
     "LazyImporter",
     "ModuleImport",

--- a/src/ducktools/lazyimporter/__init__.pyi
+++ b/src/ducktools/lazyimporter/__init__.pyi
@@ -22,6 +22,9 @@ __all__: list[str] = [
     "force_imports",
 ]
 
+EAGER_PROCESS: bool
+EAGER_IMPORT: bool
+
 class ImportBase(metaclass=abc.ABCMeta):
     module_name: str
 

--- a/src/ducktools/lazyimporter/__init__.pyi
+++ b/src/ducktools/lazyimporter/__init__.pyi
@@ -148,7 +148,8 @@ class LazyImporter:
         imports: list[ImportBase],
         *,
         globs: dict[str, Any] | None = ...,
-        eager_process: bool = ...,
+        eager_process: bool | None = ...,
+        eager_import: bool | None = ...,
     ) -> None: ...
     def __getattr__(self, name: str) -> types.ModuleType | Any: ...
     def __dir__(self): ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import sys
 import pytest
 from pathlib import Path
 
+import ducktools.lazyimporter as lazyimporter
+
 
 @pytest.fixture(scope="module", autouse=True)
 def example_modules():
@@ -14,3 +16,18 @@ def example_modules():
         yield
     finally:
         sys.path.remove(str(base_path))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def false_defaults():
+    # Tests ignore the environment variable that can set these to True
+    process_state = lazyimporter.EAGER_PROCESS
+    import_state = lazyimporter.EAGER_IMPORT
+
+    lazyimporter.EAGER_PROCESS = False
+    lazyimporter.EAGER_IMPORT = False
+
+    yield
+
+    lazyimporter.EAGER_PROCESS = process_state
+    lazyimporter.EAGER_IMPORT = import_state

--- a/tests/test_basic_imports.py
+++ b/tests/test_basic_imports.py
@@ -10,6 +10,7 @@ from ducktools.lazyimporter import (
     TryExceptImport,
     TryExceptFromImport,
     TryFallbackImport,
+    get_importer_state,
 )
 
 
@@ -188,3 +189,23 @@ class TestRelativeImports:
         from example_modules.ex_othermod import laz
 
         assert laz.submod_name == "ex_submod"
+
+
+class TestEager:
+    def test_eager_process(self):
+        laz = LazyImporter([ModuleImport("functools")], eager_process=False)
+
+        assert "_importers" not in vars(laz)
+
+        laz = LazyImporter([ModuleImport("functools")], eager_process=True)
+
+        assert "_importers" in vars(laz)
+
+    def test_eager_import(self):
+        laz = LazyImporter([ModuleImport("functools")], eager_import=False)
+
+        assert "functools" not in vars(laz)
+
+        laz = LazyImporter([ModuleImport("functools")], eager_import=True)
+
+        assert "functools" in vars(laz)

--- a/tests/test_basic_imports.py
+++ b/tests/test_basic_imports.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+import ducktools.lazyimporter as lazyimporter
+
 from ducktools.lazyimporter import (
     LazyImporter,
     ModuleImport,
@@ -209,3 +211,71 @@ class TestEager:
         laz = LazyImporter([ModuleImport("functools")], eager_import=True)
 
         assert "functools" in vars(laz)
+
+    def test_eager_process_glob(self):
+        initial_state = lazyimporter.EAGER_PROCESS
+
+        lazyimporter.EAGER_PROCESS = False
+
+        # EAGER_PROCESS = False and no value - should lazily process
+        laz = LazyImporter([ModuleImport("functools")])
+        assert "_importers" not in vars(laz)
+
+        # EAGER_PROCESS = False and eager_process = False - should lazily process
+        laz = LazyImporter([ModuleImport("functools")], eager_process=False)
+        assert "_importers" not in vars(laz)
+
+        # EAGER_PROCESS = False and eager_process = True - should eagerly process
+        laz = LazyImporter([ModuleImport("functools")], eager_process=True)
+        assert "_importers" in vars(laz)
+
+        lazyimporter.EAGER_PROCESS = True
+
+        # EAGER_PROCESS = True and no value - should eagerly process
+        laz = LazyImporter([ModuleImport("functools")])
+        assert "_importers" in vars(laz)
+
+        # EAGER_PROCESS = True and eager_process = False - should lazily process
+        laz = LazyImporter([ModuleImport("functools")], eager_process=False)
+        assert "_importers" not in vars(laz)
+
+        # EAGER_PROCESS = True and eager_process = True - should eagerly process
+        laz = LazyImporter([ModuleImport("functools")], eager_process=True)
+        assert "_importers" in vars(laz)
+
+        # Restore state
+        lazyimporter.EAGER_PROCESS = initial_state
+
+    def test_eager_import_glob(self):
+        initial_state = lazyimporter.EAGER_IMPORT
+
+        lazyimporter.EAGER_IMPORT = False
+
+        # EAGER_IMPORT = False and no value - should lazily import
+        laz = LazyImporter([ModuleImport("functools")])
+        assert "functools" not in vars(laz)
+
+        # EAGER_IMPORT = False and eager_import = False - should lazily import
+        laz = LazyImporter([ModuleImport("functools")], eager_import=False)
+        assert "functools" not in vars(laz)
+
+        # EAGER_IMPORT = False and eager_import = True - should eagerly import
+        laz = LazyImporter([ModuleImport("functools")], eager_import=True)
+        assert "functools" in vars(laz)
+
+        lazyimporter.EAGER_IMPORT = True
+
+        # EAGER_IMPORT = True and no value - should eagerly import
+        laz = LazyImporter([ModuleImport("functools")])
+        assert "functools" in vars(laz)
+
+        # EAGER_IMPORT = True and eager_import = False - should lazily import
+        laz = LazyImporter([ModuleImport("functools")], eager_import=False)
+        assert "functools" not in vars(laz)
+
+        # EAGER_IMPORT = True and eager_import = True - should eagerly import
+        laz = LazyImporter([ModuleImport("functools")], eager_import=True)
+        assert "functools" in vars(laz)
+
+        # Restore state
+        lazyimporter.EAGER_IMPORT = initial_state

--- a/tests/test_import_errors.py
+++ b/tests/test_import_errors.py
@@ -143,6 +143,16 @@ class TestNameClash:
 
         assert e.match("'matching_mod_name' used for multiple imports.")
 
+    def test_reserved_name(self):
+        with pytest.raises(ValueError) as e:
+            laz = LazyImporter(
+                [
+                    FromImport("mod1", "objname", "_importers"),
+                ],
+                eager_process=True,
+            )
+
+        assert e.match("'_importers' clashes with a LazyImporter internal name.")
 
 class TestNoGlobals:
     def test_relative_module_noglobals(self):


### PR DESCRIPTION
In some cases it may be useful to force all importers to eagerly import their attributes for testing.

This PR adds `EAGER_PROCESS` and `EAGER_IMPORT` globals along with `DUCKTOOLS_EAGER_PROCESS` and `DUCKTOOLS_EAGER_IMPORT` environment variable checks to enable this.