### PR TITLE
Fail if a submodule import without an assigned name is detected

### DIFF
--- a/src/ducktools/lazyimporter/capture.py
+++ b/src/ducktools/lazyimporter/capture.py
@@ -233,7 +233,18 @@ class capture_imports:
 
                 if attrib_name:
                     # Retrieve the captured import statement from the mapping
-                    capture = importer_map[attrib_name]
+                    try:
+                        capture = importer_map[attrib_name]
+                    except KeyError:
+                        # Search the capture map to see if this is a submodule import
+                        for cap_imp in importer_map.values():
+                            if cap_imp.module_name.split(".")[0] == attrib_name:
+                                asname = cap_imp.module_name.split(".")[-1]
+                                raise CaptureError(
+                                    f"Submodule import `import {cap_imp.module_name}` requires assigned name: "
+                                    f"eg `import {cap_imp.module_name} as {asname}`"
+                                ) from None
+                        raise
 
                     # Convert it to a regular ModuleImport or store it to make
                     # a MultiFromImport at the end.

--- a/src/ducktools/lazyimporter/capture.py
+++ b/src/ducktools/lazyimporter/capture.py
@@ -250,8 +250,11 @@ class capture_imports:
                                 raise CaptureError(
                                     f"Submodule import `import {cap_imp.module_name}` requires assigned name: "
                                     f"eg `import {cap_imp.module_name} as {asname}`"
-                                ) from None
-                        raise
+                                )
+
+                        # I don't know of a case where this can currently happen
+                        # But this is still an error so raise here
+                        raise  # pragma: nocover
 
                     # Remove used importers from the set
                     importer_set.discard(capture)
@@ -275,6 +278,10 @@ class capture_imports:
 
                     del self.globs[key]
 
+        # importer_set should be empty
+        # If it was not then there were import statements that did not have
+        # a matching name in globals.
+
         if importer_set:
             missing_module_imports = []
             missing_from_imports = []
@@ -286,7 +293,10 @@ class capture_imports:
 
             if missing_module_imports:
                 err_list = ", ".join(missing_module_imports)
-                raise CaptureError(f"Unused module import(s) {err_list} not matched to name(s) in globals.")
+                raise CaptureError(
+                    f"Unused module import(s) {err_list} not matched to a name in globals. "
+                    f"Possible duplicates or unaliased submodule import before module import."
+                )
             else:
                 err_list = ", ".join(missing_from_imports)
                 raise CaptureError(f"Imports for name(s) {err_list} found, but unused.")

--- a/tests/example_modules/captures/error_reused_from_name.py
+++ b/tests/example_modules/captures/error_reused_from_name.py
@@ -1,0 +1,8 @@
+from ducktools.lazyimporter import LazyImporter
+from ducktools.lazyimporter.capture import capture_imports
+
+
+laz = LazyImporter()
+with capture_imports(laz, auto_export=False):
+    from functools import partial as p
+    from collections import namedtuple as p

--- a/tests/example_modules/captures/error_submodule_import.py
+++ b/tests/example_modules/captures/error_submodule_import.py
@@ -1,0 +1,7 @@
+from ducktools.lazyimporter import LazyImporter
+from ducktools.lazyimporter.capture import capture_imports
+
+
+laz = LazyImporter()
+with capture_imports(laz, auto_export=False):
+    import importlib.util

--- a/tests/example_modules/captures/error_submodule_import_before_module.py
+++ b/tests/example_modules/captures/error_submodule_import_before_module.py
@@ -1,0 +1,8 @@
+from ducktools.lazyimporter import LazyImporter
+from ducktools.lazyimporter.capture import capture_imports
+
+
+laz = LazyImporter()
+with capture_imports(laz, auto_export=False):
+    import importlib.util
+    import importlib

--- a/tests/test_capture_imports.py
+++ b/tests/test_capture_imports.py
@@ -184,6 +184,10 @@ class TestExceptions:
         with pytest.raises(CaptureError):
             import example_modules.captures.error_submodule_import_before_module
 
+    def test_raises_reused_from_name(self):
+        with pytest.raises(CaptureError):
+            import example_modules.captures.error_reused_from_name
+
     def test_import_replaced(self):
         importer = builtins.__import__
         with pytest.raises(CaptureError):

--- a/tests/test_capture_imports.py
+++ b/tests/test_capture_imports.py
@@ -176,6 +176,14 @@ class TestExceptions:
         with pytest.raises(CaptureError):
             import example_modules.captures.error_dir_defined
 
+    def test_raises_submodule_import(self):
+        with pytest.raises(CaptureError):
+            import example_modules.captures.error_submodule_import
+
+    def test_raises_submodule_import_before_module(self):
+        with pytest.raises(CaptureError):
+            import example_modules.captures.error_submodule_import_before_module
+
     def test_import_replaced(self):
         importer = builtins.__import__
         with pytest.raises(CaptureError):


### PR DESCRIPTION
Closes #28 

Also this makes reusing names inside the LazyImporter into a CaptureError.