### PR TITLE
Cover additional cases

### DIFF
--- a/src/ducktools/lazyimporter/__init__.py
+++ b/src/ducktools/lazyimporter/__init__.py
@@ -830,10 +830,8 @@ def extend_imports(importer, imports):
             redo_imports.append(key)
 
     # Clear out the importers cache
-    try:
-        del importer._importers
-    except AttributeError:
-        pass
+    # Earlier call to 'dir' will create this attribute
+    del importer._importers
 
     # Add the new imports and do any necessary processing
     importer._imports.extend(imports)

--- a/tests/test_basic_imports.py
+++ b/tests/test_basic_imports.py
@@ -32,14 +32,14 @@ class TestDirectImports:
         assert "example_1" in sys.modules
 
         # Check the import is the correct object
-        import example_1  # noqa  # pyright: ignore
+        import example_1  # type: ignore
 
         assert example_1 is laz.example_1
 
     def test_module_import_asname(self):
         laz = LazyImporter([ModuleImport("example_1", asname="ex1")])
 
-        import example_1  # noqa  # pyright: ignore
+        import example_1  # type: ignore
 
         assert example_1 is laz.ex1
 
@@ -59,7 +59,7 @@ class TestDirectImports:
 
         assert laz.i == "example"
 
-        import example_2  # noqa  # pyright: ignore
+        import example_2  # type: ignore
 
         assert example_2.item is laz.i
 
@@ -147,8 +147,9 @@ class TestDirectImports:
         assert laz.name == "ex_submod"
 
     def test_try_fallback_import(self):
-        # noinspection PyUnresolvedReferences
-        import ex_mod
+        import ex_mod  # type: ignore
+        import ex_mod.ex_submod  # type: ignore
+
         test_obj = object()
 
         laz = LazyImporter(
@@ -174,6 +175,12 @@ class TestDirectImports:
         )
 
         assert laz.module_name is test_obj
+
+        laz = LazyImporter(
+            [TryFallbackImport("ex_mod.ex_submod", None, "ex_submod")]
+        )
+
+        assert laz.ex_submod == ex_mod.ex_submod
 
 
 class TestRelativeImports:

--- a/tests/test_readme_example.py
+++ b/tests/test_readme_example.py
@@ -12,13 +12,13 @@ class IfElseImporter(ImportBase):
         self.else_module_name = else_module_name
         self.asname = asname
 
-        if not self.asname.isidentifier():
+        if not self.asname.isidentifier():  # pragma: no cover
             raise ValueError(f"{self.asname} is not a valid python identifier.")
 
     def import_objects(self, globs=None):
         if globs is not None:
             package = globs.get('__name__')
-        else:
+        else:  # pragma: no cover
             package = None
 
         if self.condition:


### PR DESCRIPTION
There were a few uncovered corners that weren't tested.

Now the only bits that should show missing coverage are those that are implementation/version specific work araounds where sys._getframemodulename or sys._getframe don't exist.