### PR TITLE
Make the __dir__ function recalculate on usage to make it accurate.

### DIFF
--- a/src/ducktools/lazyimporter/__init__.py
+++ b/src/ducktools/lazyimporter/__init__.py
@@ -814,7 +814,6 @@ def get_module_funcs(importer, module_name=None):
 
     if module_name:
         mod = sys.modules[module_name]
-        dir_data = sorted(list(mod.__dict__.keys()) + dir(importer))
 
         def __getattr__(name):
             try:
@@ -826,14 +825,13 @@ def get_module_funcs(importer, module_name=None):
             setattr(mod, name, attr)
             return attr
 
+        def __dir__():
+            keyset = set(mod.__dict__.keys())
+            keyset.update(dir(importer))
+            return sorted(keyset)
+
     else:
-        dir_data = dir(importer)
-
-        def __getattr__(name):
-            return getattr(importer, name)
-
-    def __dir__():
-        return dir_data
+        raise ValueError("module name was not provided and could not be found from inspection")
 
     return __getattr__, __dir__
 

--- a/tests/example_modules/captures/extras_in_dir.py
+++ b/tests/example_modules/captures/extras_in_dir.py
@@ -1,0 +1,19 @@
+# This test file is used to test that values defined *after* the lazyimporter appear in dir
+
+from ducktools.lazyimporter import LazyImporter
+from ducktools.lazyimporter.capture import capture_imports
+
+
+_laz = LazyImporter()
+
+
+with capture_imports(_laz, auto_export=True):
+    import functools
+    from collections import namedtuple
+
+
+# These functions are defined *after* dir is set
+def extra_func():
+    pass
+
+LTUAE = 42

--- a/tests/test_capture_imports.py
+++ b/tests/test_capture_imports.py
@@ -229,3 +229,12 @@ class TestModuleCaptures:
 
         assert mod.inner_import is functools
         assert mod.InnerClass.typing is typing
+
+    def test_dir_extras(self):
+        # Test that the exported dir contains methods defined after the lazyimporter
+
+        import example_modules.captures.extras_in_dir as mod  # noqa  # pyright: ignore
+
+        assert "functools" in dir(mod)  # from the importer
+        assert "extra_func" in dir(mod)  # defined after the importer
+        assert "LTUAE" in dir(mod)  # defined after the importer

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -44,11 +44,11 @@ class TestModuleFuncs:
         assert getattr_func("collections") is collections
 
     def test_dir_func(self):
-        laz = LazyImporter([ModuleImport("collections")])
+        laz = LazyImporter([ModuleImport("fake_module")])
 
         _, dir_func = get_module_funcs(laz)
 
-        dir_vals = sorted(["collections", *globals().keys()])
+        dir_vals = sorted({"fake_module", *globals().keys()})
 
         assert dir_func() == dir_vals
 
@@ -78,6 +78,7 @@ def test_force_imports():
         "imported_attributes": {"name": "ex_mod"},
         "lazy_attributes": [],
     }
+
 
 class TestExtendImports:
     def test_lazy_example(self):


### PR DESCRIPTION
Fixes capture_imports at the top of a module leading to elements missing from __dir__